### PR TITLE
Fixed Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM openjdk:8-jre-alpine
 
 EXPOSE 8080
 
-COPY ./build/libs/my-app-1.0-SNAPSHOT.jar /usr/app/
+# Updated the correct path for the JAR file (java-app-1.0-SNAPSHOT.jar instead of my-app-1.0-SNAPSHOT.jar)
+# COPY ./build/libs/my-app-1.0-SNAPSHOT.jar /usr/app/ ---> Incorrect Path
+
+COPY ./build/libs/java-app-1.0-SNAPSHOT.jar /usr/app/
+
 WORKDIR /usr/app
 
 ENTRYPOINT ["java", "-jar", "my-app-1.0-SNAPSHOT.jar"]


### PR DESCRIPTION
This PR fixes the Dockerfile by updating the COPY path to correctly reference the JAR file in the build/libs/ directory.

Error Code:
COPY ./build/libs/my-app-1.0-SNAPSHOT.jar /usr/app/

Solved Code:
# Updated the correct path for the JAR file (java-app-1.0-SNAPSHOT.jar instead of my-app-1.0-SNAPSHOT.jar)
COPY ./build/libs/java-app-1.0-SNAPSHOT.jar /usr/app/